### PR TITLE
fix: tx types in bundle processing

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -3,8 +3,8 @@ import { Transaction } from "ethers";
 // Sample bundle processor. Can be extended to handle different kinds of bundle decomposition. For now it
 // simply looks for backrun txs to the demo implementation and removes them from the bundle. It is also responsible for
 // matching a given bundle type and returning the appropriate contract address and refund address.
-export function processBundle(transactions: Transaction[]): {
-  processedTransactions: Transaction[];
+export function processBundle(transactions: string[]): {
+  processedTransactions: string[];
   processedBundle: boolean;
   oevShare: string;
   refundAddress: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,8 @@ app.all("*", async (req, res) => {
       // Construct the bundle with the modified payload to backrun the UnlockLatestValue call.
       const bundle: Array<{ hash: string } | { tx: string; canRevert: boolean }> = [
         { hash: updateTx },
-        ...processedTransactions.map((tx: Transaction): { tx: string; canRevert: boolean } => {
-          return { tx: tx.serialized, canRevert: false };
+        ...processedTransactions.map((tx): { tx: string; canRevert: boolean } => {
+          return { tx, canRevert: false };
         }),
       ];
 


### PR DESCRIPTION
eth_sendBundle receives already signed transactions, there is no need to serialize them again.
This was causing to forward empty bundle transactions