### PR TITLE
fix: dont delete funding tx

### DIFF
--- a/src/abi/OevShare.ts
+++ b/src/abi/OevShare.ts
@@ -1,5 +1,5 @@
 // Todo: move to using typechain exports
-export const oevOracleAbi = [
+export const oevShareAbi = [
   {
     inputs: [
       { internalType: "address", name: "chainlinkSource", type: "address" },

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -1,1 +1,1 @@
-export * from "./OevOracle";
+export * from "./OevShare";

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,38 +1,5 @@
-import { Transaction } from "ethers";
 import { Request, Response, NextFunction } from "express";
 import { createJSONRPCErrorResponse, JSONRPCErrorException } from "json-rpc-2.0";
-import { env, copyAndDrop } from "../lib";
-
-// Sample bundle processor. Can be extended to handle different kinds of bundle decomposition. For now it
-// simply looks for backrun txs to the demo implementation and removes them from the bundle. It is also responsible for
-// matching a given bundle type and returning the appropriate contract address and refund address.
-export function processBundle(transactions: string[]):
-  | {
-      processedTransactions: string[];
-      foundOEVTransaction: true;
-      oevShare: string;
-      refundAddress: string;
-    }
-  | { foundOEVTransaction: false } {
-  for (const [index, tx] of transactions.entries()) {
-    const target = Transaction.from(tx);
-
-    if (target.to === env.honeyPot && target.data === "0x4d54a8ca") {
-      // Notes:
-      // 1. Right now, this does not check for multiple calls that match, as that is unexpected. Open question: how should that be handled?
-      // 2. Copy transactions to avoid modifying the input, which the calling code might not expect.
-      return {
-        foundOEVTransaction: true,
-        oevShare: env.oevOracle,
-        refundAddress: env.refundAddress,
-        processedTransactions: copyAndDrop(transactions, index),
-      };
-    }
-  }
-
-  // Don't return irrelevant parameters if nothing was found. Caller will have to check the boolean before accessing.
-  return { foundOEVTransaction: false };
-}
 
 // Error handler that logs error and sends JSON-RPC error response.
 export function expressErrorHandler(err: Error, req: Request, res: Response, next: NextFunction) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
 export const fallback = {
-  oevOracle: "0xb3cAcdC722470259886Abb57ceE1fEA714e86387",
+  oevShareAddress: "0xb3cAcdC722470259886Abb57ceE1fEA714e86387",
   honeyPot: "0xAFA42f17e0C4e6E80Bd743BB67ed02da2Fbd8965",
   refundAddress: "0xe4d0cC1976D637d01eC8d4429e8cA6F96254654b",
   forwardUrl: "https://relay.flashbots.net",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -16,7 +16,7 @@ export const env = {
   providerUrl: getEnvVar("PROVIDER_URL"),
   senderKey: getEnvVar("SENDER_PRIVATE_KEY"),
   forwardUrl: getEnvVar("FORWARD_URL", fallback.forwardUrl),
-  oevOracle: getAddress(getEnvVar("OEV_ORACLE_ADDRESS", fallback.oevOracle)),
+  oevShareAddress: getAddress(getEnvVar("OEV_ORACLE_ADDRESS", fallback.oevShareAddress)),
   honeyPot: getAddress(getEnvVar("HONEYPOT_ADDRESS", fallback.honeyPot)),
   refundAddress: getAddress(getEnvVar("REFUND_ADDRESS", fallback.refundAddress)),
   blockRangeSize: getInt(getEnvVar("BLOCK_RANGE_SIZE", fallback.blockRangeSize)),


### PR DESCRIPTION
Simplify RPC by prepending unlock tx to all received bundles and not deleting honeypot creation tx. This should be merged in only together with changes in fallback backrunner not submit mined honeypot creation tx as part of the bundle.

Fixes: https://linear.app/uma/issue/UMA-2031/dont-delete-tx-in-rpc