### PR TITLE
fix: provide list of builders on all MEV-Share calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,9 @@ app.post("/", async (req, res, next) => {
           maxBlock: targetBlock + env.blockRangeSize,
         },
         body: bundle,
+        privacy: {
+          builders: env.builders,
+        },
       };
 
       console.log(`Forwarded a bundle with the following BundleParams: ${JSON.stringify(bundleParams, null, 2)}`);
@@ -153,18 +156,7 @@ export const sendUnlockLatestValue = async (
         functionSelector: true,
         txHash: true,
       },
-      builders: [
-        "flashbots",
-        "f1b.io",
-        "rsync",
-        "beaverbuild.org",
-        "builder0x69",
-        "Titan",
-        "EigenPhi",
-        "boba-builder",
-        "Gambit Labs",
-        "payload",
-      ],
+      builders: env.builders,
     },
   };
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,4 +5,16 @@ export const fallback = {
   forwardUrl: "https://relay.flashbots.net",
   blockRangeSize: "25",
   refundPercent: "75",
+  builders: [
+    "flashbots",
+    "f1b.io",
+    "rsync",
+    "beaverbuild.org",
+    "builder0x69",
+    "Titan",
+    "EigenPhi",
+    "boba-builder",
+    "Gambit Labs",
+    "payload",
+  ],
 } as const;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,7 @@
 import { getAddress } from "ethers";
 import dotenv from "dotenv";
 import { fallback } from "./constants";
-import { getInt, getFloat } from "./helpers";
+import { getInt, getFloat, getStringArray } from "./helpers";
 dotenv.config({ path: ".env" });
 
 function getEnvVar(varName: string, defaultValue?: string): string {
@@ -21,4 +21,5 @@ export const env = {
   refundAddress: getAddress(getEnvVar("REFUND_ADDRESS", fallback.refundAddress)),
   blockRangeSize: getInt(getEnvVar("BLOCK_RANGE_SIZE", fallback.blockRangeSize)),
   refundPercent: getFloat(getEnvVar("REFUND_PERCENT", fallback.refundPercent)),
+  builders: getStringArray(getEnvVar("BUILDERS", JSON.stringify(fallback.builders))),
 };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -47,6 +47,21 @@ export function getInt(input: string): number {
   return output;
 }
 
+export function getStringArray(input: string): string[] {
+  let output: unknown;
+  try {
+    output = JSON.parse(input);
+  } catch {
+    throw new Error(`Value ${input} cannot be converted to an array of strings`);
+  }
+
+  if (Array.isArray(output) && output.every((el: unknown): el is string => typeof el === "string")) {
+    return output;
+  }
+
+  throw new Error(`Value ${input} is valid JSON, but is not an array of strings`);
+}
+
 // Simple type guard to ensure check that a value is defined (and help typescript understand).
 export function isDefined<T>(input: T | null | undefined): input is T {
   return input !== null && input !== undefined;


### PR DESCRIPTION
This PR does two things:
- Adds a builder array to _both_ mev_sendBundle calls.
- Adds an env variable to allow tweaking this list easily in prod.

I have a suspicion that the reason the bundles are only being included by the flashbots builder is that the privacy->builders field is left unset in the second bundle submission.

On top of that, I think I may have a theory as to why it seemed like increasing our fee increased our likelihood of inclusion: increasing the fee gives the flashbots builder more incoming $ in their block, meaning they can bid higher for the validator to include them over other builders. This would also explain why it seems fairly expensive (winning a block costs more than getting included in a block)!

Note: this is just a theory, but the reasoning seems to match what we've been seeing in prod.

Hopefully, this will lead to us being able to drop our fees substantially.