### PR TITLE
feat: debug bundle simulation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "body-parser": "^1.20.2",
     "ethers": "^6.8.0",
     "express": "^4.18.2",
+    "flashbots-ethers-v6-provider-bundle": "^0.6.1",
     "json-rpc-2.0": "^1.7.0",
     "morgan": "^1.10.0",
     "nodemon": "^3.0.1",

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from "express";
+import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
 import { createJSONRPCErrorResponse, JSONRPCErrorException } from "json-rpc-2.0";
 
 // Error handler that logs error and sends JSON-RPC error response.
@@ -10,5 +11,19 @@ export function expressErrorHandler(err: Error, req: Request, res: Response, nex
     res
       .status(200)
       .send(createJSONRPCErrorResponse(req.body.id, -32603, "Internal error", `${err.name}: ${err.message}`));
+  }
+}
+
+// Bundle simulation handler that just logs errors for debugging.
+export async function logSimulationErrors(
+  flashbotsBundleProvider: FlashbotsBundleProvider,
+  signedTransactions: string[],
+  targetBlock: number,
+) {
+  const simulationResponse = await flashbotsBundleProvider.simulate(signedTransactions, targetBlock);
+  if ("error" in simulationResponse) {
+    console.error("Simulation error:", simulationResponse.error.message);
+  } else if (simulationResponse.firstRevert && "error" in simulationResponse.firstRevert) {
+    console.error("Simulation reverted:", simulationResponse);
   }
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,6 @@
 import { JsonRpcProvider, WebSocketProvider, Network, Wallet, Provider, isHexString, Transaction } from "ethers";
 import MevShareClient from "@flashbots/mev-share-client";
+import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
 import { env } from "./env";
 
 export function getProvider() {
@@ -12,6 +13,7 @@ export async function initWallet(provider: JsonRpcProvider | WebSocketProvider) 
   return {
     wallet: new Wallet(env.senderKey).connect(provider),
     mevshare: MevShareClient.useEthereumMainnet(authSigner),
+    flashbotsBundleProvider: await FlashbotsBundleProvider.create(provider, authSigner),
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,6 +716,11 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+flashbots-ethers-v6-provider-bundle@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/flashbots-ethers-v6-provider-bundle/-/flashbots-ethers-v6-provider-bundle-0.6.1.tgz#217ed5cee653c45ef6713813c932c43589f72fd4"
+  integrity sha512-plWHWdBMUtZvcsPtjnxdG7H80K973wvCYZwp0mQ4AO5p2scdzy7MqLhJIMLJqVs9IRmIkajme/W6cTIWXIOxzw==
+
 follow-redirects@^1.15.0:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"


### PR DESCRIPTION
Adds bundle simulation for debugging purposes (e.g. discover underfunded accounts). For now this only logs any simulation errors, but could be integrated into serving `eth_callBundle` requests from the backrunner.