### PR TITLE
fix: use wantRefund for correct kickback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { createJSONRPCSuccessResponse, isJSONRPCRequest, isJSONRPCID } from "jso
 import { BundleParams } from "@flashbots/mev-share-client";
 import MevShareClient from "@flashbots/mev-share-client";
 
-import { initWallet, getProvider, env, getBaseFee, isEthSendBundleParams } from "./lib";
+import { initWallet, getProvider, env, getBaseFee, isEthSendBundleParams, ExtendedBundleParams } from "./lib";
 import { oevShareAbi } from "./abi";
 import { expressErrorHandler, logSimulationErrors } from "./handlers";
 
@@ -140,15 +140,15 @@ export const sendUnlockLatestValue = async (
 
   const signedUnlockTx = await wallet.signTransaction(tx);
 
-  // Send this as a bundle. Define the max share hints and share 70% kickback to HoneyDao (demo contract).
-  const bundleParams: BundleParams = {
+  // Send this as a bundle. Define the max share hints and share kickback to HoneyDao (demo contract).
+  const bundleParams: ExtendedBundleParams = {
     inclusion: { block: targetBlock, maxBlock: targetBlock + env.blockRangeSize },
     body: [{ tx: signedUnlockTx, canRevert: false }],
     validity: {
       refundConfig: [
         {
           address: refundAddress,
-          percent: env.refundPercent,
+          percent: 100,
         },
       ],
     },
@@ -161,6 +161,7 @@ export const sendUnlockLatestValue = async (
         txHash: true,
       },
       builders: env.builders,
+      wantRefund: env.refundPercent,
     },
   };
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,2 +1,3 @@
 export * from "./env";
 export * from "./helpers";
+export * from "./types";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,10 @@
+import { BundleParams, HintPreferences } from "@flashbots/mev-share-client";
+
+// Extend BundleParams to include undocumented wantRefund required for precise kickback to work.
+export interface ExtendedBundleParams extends BundleParams {
+  privacy?: {
+      hints?: HintPreferences,
+      builders?: Array<string>,
+      wantRefund?: number, // Optional property to set total refund percent.
+  }
+}


### PR DESCRIPTION
Currently expected refund was discounted by 90%, so out of 75% we get only ~67%. We were using `refundConfig` incorrectly as the sum of percent properties of its elements should be 100, while total refund percent should be set in undocumented `wantRefund` property.

Fixes: https://linear.app/uma/issue/UMA-2073/how-to-set-return-percentage-parameter