### PR TITLE
fix: error object logging

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -4,15 +4,15 @@ import { createJSONRPCErrorResponse, JSONRPCErrorException } from "json-rpc-2.0"
 import { Logger } from "../lib";
 
 // Error handler that logs error and sends JSON-RPC error response.
-export function expressErrorHandler(error: Error, req: Request, res: Response, next: NextFunction) {
-  if (error instanceof JSONRPCErrorException) {
-    Logger.error("JSON-RPC error", { error });
-    res.status(200).send(createJSONRPCErrorResponse(req.body.id, error.code, error.message, error.data));
+export function expressErrorHandler(err: Error, req: Request, res: Response, next: NextFunction) {
+  if (err instanceof JSONRPCErrorException) {
+    Logger.error("JSON-RPC error", { error: err });
+    res.status(200).send(createJSONRPCErrorResponse(req.body.id, err.code, err.message, err.data));
   } else {
-    Logger.error("Internal error", { error });
+    Logger.error("Internal error", { error: err });
     res
       .status(200)
-      .send(createJSONRPCErrorResponse(req.body.id, -32603, "Internal error", `${error.name}: ${error.message}`));
+      .send(createJSONRPCErrorResponse(req.body.id, -32603, "Internal error", `${err.name}: ${err.message}`));
   }
 }
 


### PR DESCRIPTION
Winston logger does not properly log error objects. In order to handle this `@uma/logger` implements formatter that checks for error key in the log object. In order to take benefit of this, we need to replace `err` key with `error`.