### PR TITLE
fix: use debug level for simulation errors

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -57,7 +57,7 @@ export function handleBundleSimulation(
   res: Response,
 ) {
   if ("error" in simulationResponse) {
-    Logger.info("Simulation error", { simulationResponse });
+    Logger.debug("Simulation error", { simulationResponse });
     if (simulationResponse.error.message.includes(unlockTxHash)) {
       // Mark as internal error if the prepended unlock tx was at fault.
       res.status(200).send(createJSONRPCErrorResponse(req.body.id, -32603, "Internal error"));


### PR DESCRIPTION
Slack transport might not handle this if the client requests too many invalid simulations.