### PR TITLE
fix: target single block

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ app.post("/", async (req, res, next) => {
       const bundleParams: BundleParams = {
         inclusion: {
           block: targetBlock,
-          maxBlock: targetBlock + env.blockRangeSize,
+          maxBlock: targetBlock,
         },
         body: bundle,
         privacy: {
@@ -185,7 +185,7 @@ const sendUnlockLatestValue = async (
 
   // Send this as a bundle. Define the max share hints and share kickback to HoneyDao (demo contract).
   const bundleParams: ExtendedBundleParams = {
-    inclusion: { block: targetBlock, maxBlock: targetBlock + env.blockRangeSize },
+    inclusion: { block: targetBlock, maxBlock: targetBlock },
     body: [{ tx: signedUnlockTx, canRevert: false }],
     validity: {
       refundConfig: [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,6 @@ export const fallback = {
   honeyPot: "0xAFA42f17e0C4e6E80Bd743BB67ed02da2Fbd8965",
   refundAddress: "0xe4d0cC1976D637d01eC8d4429e8cA6F96254654b",
   forwardUrl: "https://relay.flashbots.net",
-  blockRangeSize: "25",
   refundPercent: "90",
   builders: [
     "flashbots",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -19,7 +19,6 @@ export const env = {
   ovalAddress: getAddress(getEnvVar("OVAL_ADDRESS", fallback.ovalAddress)),
   honeyPot: getAddress(getEnvVar("HONEYPOT_ADDRESS", fallback.honeyPot)),
   refundAddress: getAddress(getEnvVar("REFUND_ADDRESS", fallback.refundAddress)),
-  blockRangeSize: getInt(getEnvVar("BLOCK_RANGE_SIZE", fallback.blockRangeSize)),
   refundPercent: getFloat(getEnvVar("REFUND_PERCENT", fallback.refundPercent)),
   builders: getStringArray(getEnvVar("BUILDERS", JSON.stringify(fallback.builders))),
 };


### PR DESCRIPTION
Searchers are targeting a single block, thus, RPC should not break this and target the same block in its mev-share requests.

Fixes: https://linear.app/uma/issue/UMA-2161/target-single-block-number-and-reduce-gas-over-estimation