### PR TITLE
feat: listen on port set in environment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,8 +159,8 @@ app.post("/", async (req, res, next) => {
 
 app.use(expressErrorHandler);
 
-app.listen(3000, () => {
-  Logger.info("Server is running on http://localhost:3000");
+app.listen(env.port, () => {
+  Logger.info(`Server is running on port ${env.port}`);
 });
 
 const createUnlockLatestValueTx = async (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,5 @@
 export const fallback = {
+  port: 3000,
   ovalAddress: "0xb3cAcdC722470259886Abb57ceE1fEA714e86387",
   refundAddress: "0xe4d0cC1976D637d01eC8d4429e8cA6F96254654b",
   forwardUrl: "https://relay.flashbots.net",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -28,6 +28,7 @@ try {
 }
 
 export const env = {
+  port: getInt(getEnvVar("PORT", fallback.port.toString())),
   authKey: getEnvVar("AUTH_PRIVATE_KEY"),
   providerUrl: getEnvVar("PROVIDER_URL"),
   ovalConfigs: getOvalConfigs(getEnvVar("OVAL_CONFIGS", stringifiedFallbackOvalConfigs)),


### PR DESCRIPTION
Make the code portable to Cloud Run by listening to the passed PORT variable as suggested in the [documentation](https://cloud.google.com/run/docs/developing)

Fixes: https://linear.app/uma/issue/UMA-2156/migrate-to-cloudrun