### PR TITLE
fix: validate private sender key

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -151,7 +151,8 @@ function isOvalConfig(input: unknown): input is OvalConfig {
     !Array.isArray(input) &&
     "unlockerKey" in input &&
     typeof input["unlockerKey"] === "string" &&
-    isHexString(input["unlockerKey"], 32) &&
+    ((!input["unlockerKey"].startsWith("0x") && isHexString("0x" + input["unlockerKey"], 32)) ||
+      isHexString(input["unlockerKey"], 32)) &&
     "refundAddress" in input &&
     isAddress(input["refundAddress"]) &&
     typeof input["refundAddress"] === "string" &&


### PR DESCRIPTION
ethers Wallet can be created from private key even if it does not have `0x` prepended. This fix also checks if it `isHexString` by prepending `0x` when it is missing.

Fixes: https://linear.app/uma/issue/UMA-2216/fix-unlocker-key-validation-in-rpc