### PR TITLE
feat: use prematched bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "author": "",
   "dependencies": {
-    "@flashbots/mev-share-client": "^0.7.10",
+    "@reinis_frp/mev-share-client": "^0.7.10",
     "@types/axios": "^0.14.0",
     "@types/body-parser": "^1.19.4",
     "@types/express": "^4.17.20",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ dotenv.config();
 import { Wallet, TransactionRequest, Interface, Transaction } from "ethers";
 import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
 import { createJSONRPCErrorResponse, createJSONRPCSuccessResponse, isJSONRPCRequest, isJSONRPCID } from "json-rpc-2.0";
-import { BundleParams } from "@flashbots/mev-share-client";
+import { BundleParams } from "@reinis_frp/mev-share-client";
 
 import {
   getProvider,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,5 @@
 import { JsonRpcProvider, Network, Wallet, Provider, isAddress, isHexString, Transaction, ethers } from "ethers";
-import MevShareClient from "@flashbots/mev-share-client";
+import MevShareClient from "@reinis_frp/mev-share-client";
 import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
 import { env } from "./env";
 import { Logger } from "./logging";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { BundleParams, HintPreferences } from "@flashbots/mev-share-client";
+import { BundleParams, HintPreferences } from "@reinis_frp/mev-share-client";
 
 // Extend BundleParams to include undocumented wantRefund required for precise kickback to work.
 export interface ExtendedBundleParams extends BundleParams {

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,15 +322,6 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.0.tgz#0709e9f4cb252351c609c6e6d8d6779a8d25edff"
   integrity sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==
 
-"@flashbots/mev-share-client@^0.7.10":
-  version "0.7.10"
-  resolved "https://registry.yarnpkg.com/@flashbots/mev-share-client/-/mev-share-client-0.7.10.tgz#f86383dd91bf3bb6d6451456ce418229814009eb"
-  integrity sha512-jK2ZejfPzNY4du4pKnu9PTxMikbgHOKhfpXgAe6g/QeDyzz1yzfGLIffxa6CaqM0ygyyUMIPs3h2pgL3MzA4tg==
-  dependencies:
-    async-mutex "^0.4.0"
-    axios "^1.3.4"
-    eventsource "^2.0.2"
-
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -751,6 +742,15 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
+"@reinis_frp/mev-share-client@^0.7.10":
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/@reinis_frp/mev-share-client/-/mev-share-client-0.7.10.tgz#e5627199b538e084e1eb720f53ceaa491fa47924"
+  integrity sha512-aOVfk8nJudMCwWVd+VZS1qpC86tmRk+PlBNXDvX30iD96AB0GylwnDYos51oN480YZOCQSF2H18rMtOFwtSJ9w==
+  dependencies:
+    async-mutex "^0.4.0"
+    axios "^1.3.4"
+    eventsource "^2.0.2"
 
 "@sapphire/async-queue@^1.5.0":
   version "1.5.0"


### PR DESCRIPTION
Improve RPC robustness by using prematched bundles. Instead of sending 2 bundles (unlock and backrun) the latency can be improved if RPC acts as mev-share node and uses nested bundles instead.

This feature depends on [this upstream fix](https://github.com/flashbots/mev-share-client-ts/pull/52) being merged and released. Before it is published we use a forked package.