### PR TITLE
fix: validate private keys

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,7 @@
 import { getAddress, parseEther } from "ethers";
 import dotenv from "dotenv";
 import { fallback } from "./constants";
-import { getInt, getFloat, getStringArray, getOvalConfigs } from "./helpers";
+import { getInt, getFloat, getStringArray, getOvalConfigs, getPrivateKey } from "./helpers";
 import { OvalConfigs } from "./types";
 dotenv.config({ path: ".env" });
 
@@ -17,7 +17,7 @@ let stringifiedFallbackOvalConfigs: string | undefined;
 try {
   const fallbackOvalConfigs: OvalConfigs = {
     [getAddress(getEnvVar("OVAL_ADDRESS", fallback.ovalAddress))]: {
-      unlockerKey: getEnvVar("SENDER_PRIVATE_KEY"),
+      unlockerKey: getPrivateKey(getEnvVar("SENDER_PRIVATE_KEY")),
       refundAddress: getEnvVar("REFUND_ADDRESS", fallback.refundAddress),
       refundPercent: getFloat(getEnvVar("REFUND_PERCENT", fallback.refundPercent)),
     }
@@ -29,7 +29,7 @@ try {
 
 export const env = {
   port: getInt(getEnvVar("PORT", fallback.port.toString())),
-  authKey: getEnvVar("AUTH_PRIVATE_KEY"),
+  authKey: getPrivateKey(getEnvVar("AUTH_PRIVATE_KEY")),
   providerUrl: getEnvVar("PROVIDER_URL"),
   ovalConfigs: getOvalConfigs(getEnvVar("OVAL_CONFIGS", stringifiedFallbackOvalConfigs)),
   forwardUrl: getEnvVar("FORWARD_URL", fallback.forwardUrl),

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -225,3 +225,11 @@ export function verifyBundleSignature(body: JSONRPCRequest, xFlashbotsSignatureH
 
   return verified ? recoveredAddress : null;
 }
+
+// Validate private key and prepend 0x prefix if missing.
+export function getPrivateKey(input: string): string {
+  // Prepend 0x if missing.
+  const privateKey = input.startsWith("0x") ? input : "0x" + input;
+  if (!isHexString(privateKey, 32)) throw new Error(`Value ${input} not a valid private key`);
+  return privateKey;
+}


### PR DESCRIPTION
Construction of bundle signer key was erroring if private key was missing 0x prefix.

Fixes: https://linear.app/uma/issue/UMA-2228/prepend-missing-0x-to-private-keys