### PR TITLE
fix: cleanup repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oval-backrunner",
+  "name": "oval-node",
   "version": "0.0.1",
   "main": "index.js",
   "author": "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,6 @@ import {
   initWallets,
   isEthCallBundleParams,
   isEthSendBundleParams,
-  ExtendedBundleParams,
   Logger,
   verifyBundleSignature,
 } from "./lib";
@@ -212,7 +211,7 @@ const createUnlockLatestValueTx = async (
     value: 0,
     gasLimit: 200000,
     data,
-    // Double the current base fee as a basic safe gas esimtate. We can make this more sophisticated in the future.
+    // Double the current base fee as a basic safe gas estimate. We can make this more sophisticated in the future.
     maxFeePerGas: baseFee * 2n,
     maxPriorityFeePerGas: 0, // searcher should pay the full tip.
   };
@@ -267,7 +266,7 @@ const findUnlock = async (
 
 const createUnlockLatestValueBundle = (signedUnlockTx: string, refundAddress: string, targetBlock: number) => {
   // Create this as a bundle. Define the max share hints and share kickback to configured refund address.
-  const bundleParams: ExtendedBundleParams = {
+  const bundleParams: BundleParams = {
     inclusion: { block: targetBlock, maxBlock: targetBlock },
     body: [{ tx: signedUnlockTx, canRevert: false }],
     validity: {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,5 @@
 export const fallback = {
   port: 3000,
-  ovalAddress: "0xb3cAcdC722470259886Abb57ceE1fEA714e86387",
-  refundAddress: "0xe4d0cC1976D637d01eC8d4429e8cA6F96254654b",
   forwardUrl: "https://relay.flashbots.net",
   refundPercent: "90",
   builders: [
@@ -16,6 +14,6 @@ export const fallback = {
     "Gambit Labs",
     "payload",
   ],
-  minNetBuilderPayment: "0.0002",
+  minNetBuilderPayment: "0",
   passThroughNonReverting: false,
 } as const;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -16,9 +16,9 @@ function getEnvVar(varName: string, defaultValue?: string): string {
 let stringifiedFallbackOvalConfigs: string | undefined;
 try {
   const fallbackOvalConfigs: OvalConfigs = {
-    [getAddress(getEnvVar("OVAL_ADDRESS", fallback.ovalAddress))]: {
+    [getAddress(getEnvVar("OVAL_ADDRESS"))]: {
       unlockerKey: getPrivateKey(getEnvVar("SENDER_PRIVATE_KEY")),
-      refundAddress: getEnvVar("REFUND_ADDRESS", fallback.refundAddress),
+      refundAddress: getEnvVar("REFUND_ADDRESS"),
       refundPercent: getFloat(getEnvVar("REFUND_PERCENT", fallback.refundPercent)),
     },
   };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -50,13 +50,6 @@ export async function getBaseFee(provider: Provider) {
   return baseFee;
 }
 
-// Simple utility function that returns a copy of an input array with a dropped element.
-export function copyAndDrop<T>(array: T[], index: number): T[] {
-  const clone = array.slice();
-  clone.splice(index, 1);
-  return clone;
-}
-
 // A wrapper around parseFloat that throws if the output is NaN.
 export function getFloat(input: string): number {
   const output = parseFloat(input);
@@ -99,7 +92,7 @@ export function getBoolean(input: string): boolean {
 }
 
 // Simple type guard to ensure check that a value is defined (and help typescript understand).
-export function isDefined<T>(input: T | null | undefined): input is T {
+function isDefined<T>(input: T | null | undefined): input is T {
   return input !== null && input !== undefined;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,14 +1,3 @@
-import { BundleParams, HintPreferences } from "@flashbots/mev-share-client";
-
-// Extend BundleParams to include undocumented wantRefund required for precise kickback to work.
-export interface ExtendedBundleParams extends BundleParams {
-  privacy?: {
-    hints?: HintPreferences;
-    builders?: Array<string>;
-    wantRefund?: number; // Optional property to set total refund percent.
-  };
-}
-
 export interface OvalConfig {
   unlockerKey: string;
   refundAddress: string;


### PR DESCRIPTION
Implements following fixes:
- package name
- remove redundant wantRefund (as we use pre-matched bundles now)
- remove fallback oval instance and refund (should be set by operator per oval instance)
- set minimum net builder payment to 0 (non-zero was used in testing, but in prod need constant refund percent for all auction participants)
- remove unused functions