### PR TITLE
feat: support x-flashbots-origin header

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -38,4 +38,5 @@ export const env = {
   passThroughNonReverting: getBoolean(
     getEnvVar("PASS_THROUGH_NON_REVERTING", fallback.passThroughNonReverting.toString()),
   ),
+  flashbotsOrigin: getEnvVar("FLASHBOTS_ORIGIN", ""),
 };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -38,5 +38,5 @@ export const env = {
   passThroughNonReverting: getBoolean(
     getEnvVar("PASS_THROUGH_NON_REVERTING", fallback.passThroughNonReverting.toString()),
   ),
-  flashbotsOrigin: getEnvVar("FLASHBOTS_ORIGIN", ""),
+  flashbotsOrigin: process.env["FLASHBOTS_ORIGIN"],
 };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -36,10 +36,10 @@ export async function initClients(provider: JsonRpcProvider, searcherPublicKey: 
   const network = {
     streamUrl: SupportedNetworks.mainnet.streamUrl,
     apiUrl: env.forwardUrl,
-    apiHeaders: env.flashbotsOrigin !== "" ? { "x-flashbots-origin": env.flashbotsOrigin } : undefined,
+    apiHeaders: env.flashbotsOrigin !== undefined ? { "x-flashbots-origin": env.flashbotsOrigin } : undefined,
   };
   const connect = new ethers.FetchRequest(env.forwardUrl);
-  if (env.flashbotsOrigin !== "") connect.setHeader("x-flashbots-origin", env.flashbotsOrigin);
+  if (env.flashbotsOrigin !== undefined) connect.setHeader("x-flashbots-origin", env.flashbotsOrigin);
 
   // Return initialized clients for MevShare and FlashbotsBundle, both authenticated using the derived private key.
   return {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,5 @@
 import { JsonRpcProvider, Network, Wallet, Provider, isAddress, isHexString, Transaction, ethers } from "ethers";
-import MevShareClient from "@flashbots/mev-share-client";
+import MevShareClient, { SupportedNetworks } from "@flashbots/mev-share-client";
 import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
 import { env } from "./env";
 import { Logger } from "./logging";
@@ -32,10 +32,19 @@ export async function initClients(provider: JsonRpcProvider, searcherPublicKey: 
   // Create an Ethereum wallet signer using the derived private key, connected to the provided JSON RPC provider.
   const authSigner = new Wallet(derivedPrivateKey).connect(provider);
 
+  // Use custom network for MevShare and connect for FlashbotsBundle as we might need adding x-flashbots-origin headers.
+  const network = {
+    streamUrl: SupportedNetworks.mainnet.streamUrl,
+    apiUrl: env.forwardUrl,
+    apiHeaders: env.flashbotsOrigin !== "" ? { "x-flashbots-origin": env.flashbotsOrigin } : undefined,
+  };
+  const connect = new ethers.FetchRequest(env.forwardUrl);
+  if (env.flashbotsOrigin !== "") connect.setHeader("x-flashbots-origin", env.flashbotsOrigin);
+
   // Return initialized clients for MevShare and FlashbotsBundle, both authenticated using the derived private key.
   return {
-    mevshare: MevShareClient.useEthereumMainnet(authSigner),
-    flashbotsBundleProvider: await FlashbotsBundleProvider.create(provider, authSigner),
+    mevshare: new MevShareClient(authSigner, network),
+    flashbotsBundleProvider: await FlashbotsBundleProvider.create(provider, authSigner, connect),
   };
 }
 


### PR DESCRIPTION
Support adding `x-flashbots-origin` header if provided in `FLASHBOTS_ORIGIN` environment.
The header is added only when handling supported methods. In pass-through mode we don't change the searcher's headers.

This will become functional only after upstream mev-share-client releases the [support for custom headers](https://github.com/flashbots/mev-share-client-ts/pull/55)

Fixes: https://linear.app/uma/issue/UMA-2295/fb-header-set-x-flashbots-origin-header-to-oval-for-requests-to