### PR TITLE
feat: add header oval configs to enable the request of oval unlocks

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -87,7 +87,11 @@ function handleForwardedRequestErrors(err: unknown, req: Request, res: Response)
 export async function handleUnsupportedRequest(req: Request, res: Response, reason?: string) {
   const { method, body } = req;
 
-  Logger.debug(req.transactionId, `Received unsupported request${reason ? `: ${reason}` : ""}! Forwarding to ${env.forwardUrl} ...`, { body });
+  Logger.debug(
+    req.transactionId,
+    `Received unsupported request${reason ? `: ${reason}` : ""}! Forwarding to ${env.forwardUrl} ...`,
+    { body },
+  );
 
   let response: AxiosResponse;
   try {

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,9 +1,9 @@
 import axios, { AxiosError, AxiosResponse } from "axios";
-import { Request, Response, NextFunction } from "express";
-import { keccak256, concat } from "ethers";
+import { concat, keccak256 } from "ethers";
+import { NextFunction, Request, Response } from "express";
 import { SimulationResponse, SimulationResponseSuccess } from "flashbots-ethers-v6-provider-bundle";
-import { createJSONRPCErrorResponse, createJSONRPCSuccessResponse, JSONRPCErrorException } from "json-rpc-2.0";
-import { env, Logger, stringifyBigInts } from "../lib";
+import { JSONRPCErrorException, createJSONRPCErrorResponse, createJSONRPCSuccessResponse } from "json-rpc-2.0";
+import { Logger, env, stringifyBigInts } from "../lib";
 
 // Error handler that logs error and sends JSON-RPC error response.
 export function expressErrorHandler(err: Error, req: Request, res: Response, next: NextFunction) {
@@ -22,9 +22,9 @@ export function expressErrorHandler(err: Error, req: Request, res: Response, nex
 // Logic based on CallBundle function implementation in https://github.com/flashbots/builder/blob/main/internal/ethapi/api.go
 function removeUnlockFromSimulationResult(
   simulationResponse: SimulationResponseSuccess,
-  unlockTxHash: string,
+  unlockTxHashes: string[],
 ): SimulationResponseSuccess {
-  const results = simulationResponse.results.filter((txResponse) => txResponse.txHash !== unlockTxHash);
+  const results = simulationResponse.results.filter((txResponse) => !unlockTxHashes.includes(txResponse.txHash));
   const coinbaseDiff = results.reduce((total, txResponse) => total + BigInt(txResponse.coinbaseDiff), 0n);
   const gasFees = results.reduce((total, txResponse) => total + BigInt(txResponse.gasFees), 0n);
   const totalGasUsed = results.reduce((total, txResponse) => total + txResponse.gasUsed, 0);
@@ -44,13 +44,17 @@ function removeUnlockFromSimulationResult(
 // Bundle simulation handler that sends simulation response to the client without the unlock transaction.
 export function handleBundleSimulation(
   simulationResponse: SimulationResponse,
-  unlockTxHash: string,
+  unlockTxHashes: string[],
   req: Request,
   res: Response,
 ) {
   if ("error" in simulationResponse) {
     Logger.debug(req.transactionId, "Simulation error", { simulationResponse });
-    if (simulationResponse.error.message.includes(unlockTxHash)) {
+
+    // Check if any of the unlockTxHashes is included in the error message
+    const isUnlockTxHashError = unlockTxHashes.some((hash) => simulationResponse.error.message.includes(hash));
+
+    if (isUnlockTxHashError) {
       // Mark as internal error if the prepended unlock tx was at fault.
       res.status(200).send(createJSONRPCErrorResponse(req.body.id, -32603, "Internal error"));
     } else {
@@ -61,7 +65,7 @@ export function handleBundleSimulation(
     }
     return;
   } else {
-    const clientSimulationResult = removeUnlockFromSimulationResult(simulationResponse, unlockTxHash);
+    const clientSimulationResult = removeUnlockFromSimulationResult(simulationResponse, unlockTxHashes);
     res.status(200).send(createJSONRPCSuccessResponse(req.body.id, stringifyBigInts(clientSimulationResult)));
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,36 +1,40 @@
-import express, { Request } from "express";
 import bodyParser from "body-parser";
 import dotenv from "dotenv";
+import express from "express";
 import morgan from "morgan";
 import { v4 as uuidv4 } from "uuid";
 import "./lib/express-extensions";
 
 dotenv.config();
 
-import { Wallet, TransactionRequest, Interface, Transaction } from "ethers";
-import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
-import { createJSONRPCErrorResponse, createJSONRPCSuccessResponse, isJSONRPCRequest, isJSONRPCID } from "json-rpc-2.0";
 import { BundleParams } from "@flashbots/mev-share-client";
+import { createJSONRPCErrorResponse, isJSONRPCID, isJSONRPCRequest } from "json-rpc-2.0";
 
-import {
-  getProvider,
-  env,
-  getBaseFee,
-  initClients,
-  initWallets,
-  isEthCallBundleParams,
-  isEthSendBundleParams,
-  Logger,
-  verifyBundleSignature,
-  getMaxBlockByChainId,
-} from "./lib";
-import { ovalAbi } from "./abi";
 import {
   expressErrorHandler,
   handleBundleSimulation,
   handleUnsupportedRequest,
   originalBundleReverts,
 } from "./handlers";
+import {
+  FLASHBOTS_SIGNATURE_HEADER,
+  Logger,
+  OVAL_CONFIG_HEADER,
+  Refund,
+  adjustRefundPercent,
+  calculateBundleRefunds,
+  createUnlockLatestValueBundle,
+  env,
+  findUnlock,
+  getOvalHeaderConfigs,
+  getProvider,
+  getUnlockBundlesFromOvalAddresses,
+  initClients,
+  isEthCallBundleParams,
+  isEthSendBundleParams,
+  sendBundle,
+  verifyBundleSignature
+} from "./lib";
 
 const app = express();
 app.use(bodyParser.json());
@@ -41,9 +45,7 @@ app.use((req, res, next) => {
 });
 
 const provider = getProvider();
-const unlockerWallets = initWallets(provider);
 const { ovalConfigs } = env;
-const ovalInterface = Interface.from(ovalAbi);
 
 // Start restful API server to listen for root inbound post requests.
 app.post("/", async (req, res, next) => {
@@ -57,12 +59,19 @@ app.post("/", async (req, res, next) => {
     }
 
     // Verify that the signature in the request headers matches the bundle payload.
-    const verifiedSignatureSearcherPkey = verifyBundleSignature(body, req.headers["x-flashbots-signature"], req);
+    const verifiedSignatureSearcherPkey = verifyBundleSignature(body, req.headers[FLASHBOTS_SIGNATURE_HEADER], req);
+
+    // Get Oval header configs if present.
+    const { valid, ovalHeaderConfigs } = getOvalHeaderConfigs(req.headers[OVAL_CONFIG_HEADER], ovalConfigs);
+    if (!valid) {
+      await handleUnsupportedRequest(req, res, "Error parsing Oval header configs");
+      return;
+    }
 
     // Prepend the unlock transaction if the request is a valid JSON RPC 2.0 'eth_sendBundle' method with a valid bundle signature.
     if (verifiedSignatureSearcherPkey && body.method == "eth_sendBundle") {
       if (!isEthSendBundleParams(body.params)) {
-        Logger.info(req.transactionId, "Received unsupported eth_sendBundle request!", { body });
+        Logger.debug(req.transactionId, "Received unsupported eth_sendBundle request!", { body });
         res.status(200).send(createJSONRPCErrorResponse(body.id, -32000, "Unsupported eth_sendBundle params"));
         return;
       }
@@ -74,78 +83,85 @@ app.post("/", async (req, res, next) => {
 
       const { mevshare, flashbotsBundleProvider } = await initClients(provider, verifiedSignatureSearcherPkey);
 
-      // If configured, simulate the original bundle to check if it reverts without the unlock.
-      if (env.passThroughNonReverting) {
-        const originalSimulationResponse = await flashbotsBundleProvider.simulate(backrunTxs, targetBlock);
-        if (!originalBundleReverts(originalSimulationResponse, req)) {
-          await handleUnsupportedRequest(req, res, "Original bundle does not revert"); // Pass through if the original bundle doesn't revert.
+      let bundle: BundleParams["body"], refunds: Refund[];
+      // If ovalHeaderConfigs.unlockAddresses are configured, send the unlock transaction bundles and the backrun bundle without simulation.
+      // This setting enables the searcher to request a specific list of unlock addresses for use in their bundle and
+      // accelerates the process by omitting the step of finding unlock addresses and performing simulations.
+      if (ovalHeaderConfigs) {
+        const ovalAddresses = ovalHeaderConfigs.unlockAddresses.map((unlockAddress) => unlockAddress.ovalAddress);
+        const { unlockBundles } = await getUnlockBundlesFromOvalAddresses(flashbotsBundleProvider, backrunTxs, targetBlock, ovalAddresses, req);
+
+        Logger.debug(req.transactionId, "Header unlock addresses found. Sending unlock tx bundle and backrun bundle...", ovalAddresses);
+        // Construct the outer bundle with the modified payload to backrun the UnlockLatestValue call.
+        bundle = [
+          ...unlockBundles,
+          ...backrunTxs.map((tx): { tx: string; canRevert: boolean } => {
+            return { tx, canRevert: false };
+          }),
+        ];
+
+        // Calculate refunds for the each unlock bundles this assumes the unlock bundles are the first elements in the bundle
+        // and the ovalAddresses are in the same order as the unlock bundles.
+        refunds = calculateBundleRefunds(ovalAddresses, ovalConfigs);
+
+        return sendBundle(req, res, mevshare, targetBlock, body.id, bundle, refunds);
+      } else {
+
+        // If configured, simulate the original bundle to check if it reverts without the unlock.
+        if (env.passThroughNonReverting) {
+          const originalSimulationResponse = await flashbotsBundleProvider.simulate(backrunTxs, targetBlock);
+          if (!originalBundleReverts(originalSimulationResponse, req)) {
+            await handleUnsupportedRequest(req, res, "Original bundle does not revert"); // Pass through if the original bundle doesn't revert.
+            return;
+          }
+        }
+
+        Logger.debug(req.transactionId, "Finding unlock that does not revert the bundle...");
+
+        const unlock = await findUnlock(flashbotsBundleProvider, backrunTxs, targetBlock, req);
+        if (!unlock) {
+          Logger.debug(req.transactionId, "No valid unlock found!");
+          await handleUnsupportedRequest(req, res, "No valid unlock found"); // Pass through if no unlock is found.
           return;
         }
+        // Dynamically adjust refund percent so that builder nets at least configured minimum. We don't need to consider
+        // refund gas costs as the builder is deducting them from refund and should not include the bundle if refund gas
+        // costs exceed refund value.
+        const adjustedRefundPercent = adjustRefundPercent(
+          unlock.simulationResponse.coinbaseDiff,
+          ovalConfigs[unlock.ovalAddress].refundPercent,
+        );
+        if (adjustedRefundPercent <= 0) {
+          Logger.debug(req.transactionId, `Insufficient builder payment ${unlock.simulationResponse.coinbaseDiff}`);
+          await handleUnsupportedRequest(req, res, "Insufficient builder payment"); // Pass through as minimum payment not met.
+          return;
+        }
+
+        Logger.debug(
+          req.transactionId,
+          `Found valid unlock at ${unlock.ovalAddress}. Sending unlock tx bundle and backrun bundle...`,
+        );
+
+        // Construct the inner bundle with call to Oval to unlock the latest value.
+        const unlockBundle = createUnlockLatestValueBundle(
+          unlock.signedUnlockTx,
+          ovalConfigs[unlock.ovalAddress].refundAddress,
+          targetBlock,
+        );
+
+        // Construct the outer bundle with the modified payload to backrun the UnlockLatestValue call.
+        bundle = [
+          { bundle: unlockBundle },
+          ...backrunTxs.map((tx): { tx: string; canRevert: boolean } => {
+            return { tx, canRevert: false };
+          }),
+        ];
+        refunds = [{ bodyIdx: 0, percent: adjustedRefundPercent }]
       }
 
-      Logger.debug(req.transactionId, "Finding unlock that does not revert the bundle...");
+      // Exit the function here to prevent the request from being forwarded to the FORWARD_URL.
+      return sendBundle(req, res, mevshare, targetBlock, body.id, bundle, refunds);
 
-      const unlock = await findUnlock(flashbotsBundleProvider, backrunTxs, targetBlock, req);
-      if (!unlock) {
-        Logger.debug(req.transactionId, "No valid unlock found!");
-        await handleUnsupportedRequest(req, res, "No valid unlock found"); // Pass through if no unlock is found.
-        return;
-      }
-
-      // Dynamically adjust refund percent so that builder nets at least configured minimum. We don't need to consider
-      // refund gas costs as the builder is deducting them from refund and should not include the bundle if refund gas
-      // costs exceed refund value.
-      const adjustedRefundPercent = adjustRefundPercent(
-        unlock.simulationResponse.coinbaseDiff,
-        ovalConfigs[unlock.ovalAddress].refundPercent,
-      );
-      if (adjustedRefundPercent <= 0) {
-        Logger.debug(req.transactionId, `Insufficient builder payment ${unlock.simulationResponse.coinbaseDiff}`);
-        await handleUnsupportedRequest(req, res, "Insufficient builder payment"); // Pass through as minimum payment not met.
-        return;
-      }
-
-      Logger.debug(
-        req.transactionId,
-        `Found valid unlock at ${unlock.ovalAddress}. Sending unlock tx bundle and backrun bundle...`,
-      );
-
-      // Construct the inner bundle with call to Oval to unlock the latest value.
-      const unlockBundle = createUnlockLatestValueBundle(
-        unlock.signedUnlockTx,
-        ovalConfigs[unlock.ovalAddress].refundAddress,
-        targetBlock,
-      );
-
-      // Construct the outer bundle with the modified payload to backrun the UnlockLatestValue call.
-      const bundle: BundleParams["body"] = [
-        { bundle: unlockBundle },
-        ...backrunTxs.map((tx): { tx: string; canRevert: boolean } => {
-          return { tx, canRevert: false };
-        }),
-      ];
-
-      const bundleParams: BundleParams = {
-        inclusion: {
-          block: targetBlock,
-          maxBlock: getMaxBlockByChainId(env.chainId, targetBlock),
-        },
-        body: bundle,
-        privacy: {
-          builders: env.builders,
-        },
-        validity: {
-          refund: [{ bodyIdx: 0, percent: adjustedRefundPercent }],
-        },
-      };
-
-      const backrunResult = await mevshare.sendBundle(bundleParams);
-
-      Logger.debug(req.transactionId, "Forwarded a bundle to MEV-Share", { bundleParams });
-      Logger.info(req.transactionId, "Bundle accepted by MEV-Share", { bundleHash: backrunResult.bundleHash });
-
-      res.status(200).send(createJSONRPCSuccessResponse(body.id, backrunResult));
-      return; // Exit the function here to prevent the request from being forwarded to the FORWARD_URL.
     } else if (verifiedSignatureSearcherPkey && body.method == "eth_callBundle") {
       if (!isEthCallBundleParams(body.params)) {
         Logger.info(req.transactionId, "Received unsupported eth_callBundle request!", { body });
@@ -169,27 +185,42 @@ app.post("/", async (req, res, next) => {
         }
       }
 
-      Logger.debug(req.transactionId, "Finding unlock that does not revert the bundle...");
+      let simulationResponse, unlockTransactionHashes;
+      if (ovalHeaderConfigs) {
+        const ovalAddresses = ovalHeaderConfigs.unlockAddresses.map((unlockAddress) => unlockAddress.ovalAddress);
+        Logger.debug(req.transactionId, "Header unlock addresses found: simulating unlock tx bundle and backrun bundle...", ovalAddresses);
 
-      const unlock = await findUnlock(flashbotsBundleProvider, backrunTxs, targetBlock, req);
-      if (!unlock) {
-        Logger.debug(req.transactionId, "No valid unlock found!");
-        await handleUnsupportedRequest(req, res, "No valid unlock found"); // Pass through if no unlock is found.
-        return;
+        const { unlockSignedTransactions, unlockTxHashes } = await getUnlockBundlesFromOvalAddresses(flashbotsBundleProvider, backrunTxs, targetBlock, ovalAddresses, req);
+        simulationResponse = await flashbotsBundleProvider.simulate(
+          [...unlockSignedTransactions, ...backrunTxs],
+          targetBlock,
+        );
+        unlockTransactionHashes = unlockTxHashes;
+      } else {
+        Logger.debug(req.transactionId, "Finding unlock that does not revert the bundle...");
+
+        const unlock = await findUnlock(flashbotsBundleProvider, backrunTxs, targetBlock, req);
+        if (!unlock) {
+          Logger.debug(req.transactionId, "No valid unlock found!");
+          await handleUnsupportedRequest(req, res, "No valid unlock found"); // Pass through if no unlock is found.
+          return;
+        }
+
+        Logger.debug(
+          req.transactionId,
+          `Found valid unlock at ${unlock.ovalAddress}. Simulating unlock tx bundle and backrun bundle...`,
+        );
+
+        simulationResponse = await flashbotsBundleProvider.simulate(
+          [unlock.signedUnlockTx, ...backrunTxs],
+          targetBlock,
+        );
+        unlockTransactionHashes = [unlock.unlockTxHash];
       }
 
-      Logger.debug(
-        req.transactionId,
-        `Found valid unlock at ${unlock.ovalAddress}. Simulating unlock tx bundle and backrun bundle...`,
-      );
-
-      const simulationResponse = await flashbotsBundleProvider.simulate(
-        [unlock.signedUnlockTx, ...backrunTxs],
-        targetBlock,
-      );
-
       // Send back the simulation response without the unlock transaction.
-      handleBundleSimulation(simulationResponse, unlock.unlockTxHash, req, res);
+      return handleBundleSimulation(simulationResponse, unlockTransactionHashes, req, res);
+
     } else await handleUnsupportedRequest(req, res, "Invalid signature or method");
   } catch (error) {
     next(error);
@@ -206,116 +237,3 @@ app.use(expressErrorHandler);
 app.listen(env.port, () => {
   Logger.debug("Startup", `Server is running on port ${env.port}`);
 });
-
-const createUnlockLatestValueTx = async (
-  wallet: Wallet,
-  baseFee: bigint,
-  data: string,
-  chainId: bigint,
-  ovalAddress: string,
-) => {
-  const nonce = await wallet.getNonce();
-
-  // Construct transaction to call unlockLatestValue on Oval Oracle from permissioned address.
-  const unlockTx: TransactionRequest = {
-    type: 2,
-    chainId,
-    to: ovalAddress,
-    nonce,
-    value: 0,
-    gasLimit: 200000,
-    data,
-    // Double the current base fee as a basic safe gas estimate. We can make this more sophisticated in the future.
-    maxFeePerGas: baseFee * 2n,
-    maxPriorityFeePerGas: 0, // searcher should pay the full tip.
-  };
-
-  const signedUnlockTx = await wallet.signTransaction(unlockTx);
-
-  const unlockTxHash = Transaction.from(signedUnlockTx).hash;
-  if (!unlockTxHash) throw new Error("No hash in signed unlock transaction");
-
-  return { unlockTxHash, signedUnlockTx };
-};
-
-// Simulate calls to unlockLatestValue on each Oval instance bundled with original backrun transactions. Tries to find
-// the first unlock that doesn't revert the bundle.
-const findUnlock = async (
-  flashbotsBundleProvider: FlashbotsBundleProvider,
-  backrunTxs: string[],
-  targetBlock: number,
-  req: express.Request,
-) => {
-  const [baseFee, network] = await Promise.all([getBaseFee(provider, req), provider.getNetwork()]);
-  const data = ovalInterface.encodeFunctionData("unlockLatestValue");
-
-  const unlocks = await Promise.all(
-    Object.keys(ovalConfigs).map(async (ovalAddress) => {
-      const { unlockTxHash, signedUnlockTx } = await createUnlockLatestValueTx(
-        unlockerWallets[ovalAddress],
-        baseFee,
-        data,
-        network.chainId,
-        ovalAddress,
-      );
-
-      const simulationResponse = await flashbotsBundleProvider.simulate([signedUnlockTx, ...backrunTxs], targetBlock);
-
-      return { ovalAddress, unlockTxHash, signedUnlockTx, simulationResponse };
-    }),
-  );
-
-  // Find the first unlock that doesn't revert.
-  for (const unlock of unlocks) {
-    if (!("error" in unlock.simulationResponse) && !unlock.simulationResponse.firstRevert) {
-      return {
-        // Spread in order to preserve inferred SimulationResponseSuccess type.
-        ...unlock,
-        simulationResponse: unlock.simulationResponse,
-      };
-    }
-  }
-
-  return undefined;
-};
-
-const createUnlockLatestValueBundle = (signedUnlockTx: string, refundAddress: string, targetBlock: number) => {
-  // Create this as a bundle. Define the max share hints and share kickback to configured refund address.
-  const bundleParams: BundleParams = {
-    inclusion: { block: targetBlock, maxBlock: getMaxBlockByChainId(env.chainId, targetBlock) },
-    body: [{ tx: signedUnlockTx, canRevert: false }],
-    validity: {
-      refundConfig: [
-        {
-          address: refundAddress,
-          percent: 100,
-        },
-      ],
-    },
-    privacy: {
-      hints: {
-        calldata: true,
-        logs: true,
-        contractAddress: true,
-        functionSelector: true,
-        txHash: true,
-      },
-      builders: env.builders,
-    },
-  };
-
-  return bundleParams;
-};
-
-// Adjusts refund percent to ensure that net builder captured value reaches the minimum configured amount.
-// This can still return 0 if gross builder payment is not sufficient and caller should handle this.
-const adjustRefundPercent = (grossBuilderPayment: bigint, originalRefundPercent: number) => {
-  // Require positive builder payment that covers at least minNetBuilderPaymentWei.
-  if (grossBuilderPayment <= 0 || grossBuilderPayment < env.minNetBuilderPaymentWei) return 0;
-
-  // No need for scaling as Flashbots accepts only integer refund percent value.
-  const maxRefundPercent = Number(((grossBuilderPayment - env.minNetBuilderPaymentWei) * 100n) / grossBuilderPayment);
-
-  // Bound adjusted refund percent by maxRefundPercent.
-  return Math.min(originalRefundPercent, maxRefundPercent);
-};

--- a/src/lib/bundleUtils.ts
+++ b/src/lib/bundleUtils.ts
@@ -5,11 +5,14 @@ import { getBaseFee, getMaxBlockByChainId, getProvider, initWallets } from "./he
 
 import MevShareClient, { BundleParams } from "@flashbots/mev-share-client";
 import { JSONRPCID, createJSONRPCSuccessResponse } from "json-rpc-2.0";
+
 import { ovalAbi } from "../abi";
 import { env } from "./env";
 import { Logger } from "./logging";
 import { Refund } from "./types";
 const { ovalConfigs } = env;
+
+export const ovalInterface = Interface.from(ovalAbi);
 
 export const createUnlockLatestValueTx = async (
   wallet: Wallet,
@@ -53,7 +56,6 @@ export const prepareUnlockTransaction = async (
 ) => {
   const provider = getProvider();
   const unlockerWallets = initWallets(provider);
-  const ovalInterface = Interface.from(ovalAbi);
   const [baseFee, network] = await Promise.all([getBaseFee(provider, req), provider.getNetwork()]);
   const data = ovalInterface.encodeFunctionData("unlockLatestValue");
   const { unlockTxHash, signedUnlockTx } = await createUnlockLatestValueTx(

--- a/src/lib/bundleUtils.ts
+++ b/src/lib/bundleUtils.ts
@@ -4,176 +4,208 @@ import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
 import { getBaseFee, getMaxBlockByChainId, getProvider, initWallets } from "./helpers";
 
 import MevShareClient, { BundleParams } from "@flashbots/mev-share-client";
-import { Logger } from "@uma/logger";
 import { JSONRPCID, createJSONRPCSuccessResponse } from "json-rpc-2.0";
 import { ovalAbi } from "../abi";
 import { env } from "./env";
+import { Logger } from "./logging";
 import { Refund } from "./types";
 const { ovalConfigs } = env;
 
 export const createUnlockLatestValueTx = async (
-    wallet: Wallet,
-    baseFee: bigint,
-    data: string,
-    chainId: bigint,
-    ovalAddress: string,
+  wallet: Wallet,
+  baseFee: bigint,
+  data: string,
+  chainId: bigint,
+  ovalAddress: string,
 ) => {
-    const nonce = await wallet.getNonce();
+  const nonce = await wallet.getNonce();
 
-    // Construct transaction to call unlockLatestValue on Oval Oracle from permissioned address.
-    const unlockTx: TransactionRequest = {
-        type: 2,
-        chainId,
-        to: ovalAddress,
-        nonce,
-        value: 0,
-        gasLimit: 200000,
-        data,
-        // Double the current base fee as a basic safe gas estimate. We can make this more sophisticated in the future.
-        maxFeePerGas: baseFee * 2n,
-        maxPriorityFeePerGas: 0, // searcher should pay the full tip.
-    };
+  // Construct transaction to call unlockLatestValue on Oval Oracle from permissioned address.
+  const unlockTx: TransactionRequest = {
+    type: 2,
+    chainId,
+    to: ovalAddress,
+    nonce,
+    value: 0,
+    gasLimit: 200000,
+    data,
+    // Double the current base fee as a basic safe gas estimate. We can make this more sophisticated in the future.
+    maxFeePerGas: baseFee * 2n,
+    maxPriorityFeePerGas: 0, // searcher should pay the full tip.
+  };
 
-    const signedUnlockTx = await wallet.signTransaction(unlockTx);
+  const signedUnlockTx = await wallet.signTransaction(unlockTx);
 
-    const unlockTxHash = Transaction.from(signedUnlockTx).hash;
-    if (!unlockTxHash) throw new Error("No hash in signed unlock transaction");
+  const unlockTxHash = Transaction.from(signedUnlockTx).hash;
+  if (!unlockTxHash) throw new Error("No hash in signed unlock transaction");
 
-    return { unlockTxHash, signedUnlockTx };
+  return { unlockTxHash, signedUnlockTx };
 };
 
 // Prepare unlockLatestValue transaction for a given Oval instance and simulate the bundle with the unlock transaction prepended if simulate is true.
-export const prepareUnlockTransaction = async (flashbotsBundleProvider: FlashbotsBundleProvider, backrunTxs: string[], targetBlock: number, ovalAddress: string, req: express.Request, simulate = true) => {
-    const provider = getProvider();
-    const unlockerWallets = initWallets(provider);
-    const ovalInterface = Interface.from(ovalAbi);
-    const [baseFee, network] = await Promise.all([getBaseFee(provider, req), provider.getNetwork()]);
-    const data = ovalInterface.encodeFunctionData("unlockLatestValue");
-    const { unlockTxHash, signedUnlockTx } = await createUnlockLatestValueTx(
-        unlockerWallets[ovalAddress],
-        baseFee,
-        data,
-        network.chainId,
-        ovalAddress,
+export const prepareUnlockTransaction = async (
+  flashbotsBundleProvider: FlashbotsBundleProvider,
+  backrunTxs: string[],
+  targetBlock: number,
+  ovalAddress: string,
+  req: express.Request,
+  simulate = true,
+) => {
+  const provider = getProvider();
+  const unlockerWallets = initWallets(provider);
+  const ovalInterface = Interface.from(ovalAbi);
+  const [baseFee, network] = await Promise.all([getBaseFee(provider, req), provider.getNetwork()]);
+  const data = ovalInterface.encodeFunctionData("unlockLatestValue");
+  const { unlockTxHash, signedUnlockTx } = await createUnlockLatestValueTx(
+    unlockerWallets[ovalAddress],
+    baseFee,
+    data,
+    network.chainId,
+    ovalAddress,
+  );
+
+  if (!simulate) return { ovalAddress, unlockTxHash, signedUnlockTx };
+
+  const simulationResponse = await flashbotsBundleProvider.simulate([signedUnlockTx, ...backrunTxs], targetBlock);
+
+  return { ovalAddress, unlockTxHash, signedUnlockTx, simulationResponse };
+};
+
+export const getUnlockBundlesFromOvalAddresses = async (
+  flashbotsBundleProvider: FlashbotsBundleProvider,
+  backrunTxs: string[],
+  targetBlock: number,
+  ovalAddresses: string[],
+  req: express.Request,
+) => {
+  const unlockBundles = [];
+  const unlockSignedTransactions = [];
+  const unlockTxHashes = [];
+  for (const ovalAddress of ovalAddresses) {
+    const unlock = await prepareUnlockTransaction(
+      flashbotsBundleProvider,
+      backrunTxs,
+      targetBlock,
+      ovalAddress,
+      req,
+      false,
     );
 
-    if (!simulate) return { ovalAddress, unlockTxHash, signedUnlockTx };
+    // Construct the inner bundle with call to Oval to unlock the latest value.
+    const unlockBundle = createUnlockLatestValueBundle(
+      unlock.signedUnlockTx,
+      ovalConfigs[ovalAddress].refundAddress,
+      targetBlock,
+    );
 
-    const simulationResponse = await flashbotsBundleProvider.simulate([signedUnlockTx, ...backrunTxs], targetBlock);
-
-    return { ovalAddress, unlockTxHash, signedUnlockTx, simulationResponse };
-}
-
-export const getUnlockBundlesFromOvalAddresses = async (flashbotsBundleProvider: FlashbotsBundleProvider, backrunTxs: string[], targetBlock: number, ovalAddresses: string[], req: express.Request) => {
-    const unlockBundles = [];
-    const unlockSignedTransactions = [];
-    const unlockTxHashes = [];
-    for (const ovalAddress in ovalAddresses) {
-        const unlock = await prepareUnlockTransaction(flashbotsBundleProvider, backrunTxs, targetBlock, ovalAddress, req, false);
-
-        // Construct the inner bundle with call to Oval to unlock the latest value.
-        const unlockBundle = createUnlockLatestValueBundle(
-            unlock.signedUnlockTx,
-            ovalConfigs[ovalAddress].refundAddress,
-            targetBlock,
-        );
-
-        unlockBundles.push({ bundle: unlockBundle });
-        unlockSignedTransactions.push(unlock.signedUnlockTx);
-        unlockTxHashes.push(unlock.unlockTxHash);
-    }
-    return { unlockBundles, unlockSignedTransactions, unlockTxHashes };
-}
+    unlockBundles.push({ bundle: unlockBundle });
+    unlockSignedTransactions.push(unlock.signedUnlockTx);
+    unlockTxHashes.push(unlock.unlockTxHash);
+  }
+  return { unlockBundles, unlockSignedTransactions, unlockTxHashes };
+};
 
 // Simulate calls to unlockLatestValue on each Oval instance bundled with original backrun transactions. Tries to find
 // the first unlock that doesn't revert the bundle.
 export const findUnlock = async (
-    flashbotsBundleProvider: FlashbotsBundleProvider,
-    backrunTxs: string[],
-    targetBlock: number,
-    req: express.Request,
+  flashbotsBundleProvider: FlashbotsBundleProvider,
+  backrunTxs: string[],
+  targetBlock: number,
+  req: express.Request,
 ) => {
-    const unlocks = await Promise.all(
-        Object.keys(ovalConfigs).map(async (ovalAddress) => (prepareUnlockTransaction(flashbotsBundleProvider, backrunTxs, targetBlock, ovalAddress, req))),
-    );
+  const unlocks = await Promise.all(
+    Object.keys(ovalConfigs).map(async (ovalAddress) =>
+      prepareUnlockTransaction(flashbotsBundleProvider, backrunTxs, targetBlock, ovalAddress, req),
+    ),
+  );
 
-    // Find the first unlock that doesn't revert.
-    for (const unlock of unlocks) {
-        if (unlock.simulationResponse && !("error" in unlock.simulationResponse) && !unlock.simulationResponse.firstRevert) {
-            return {
-                // Spread in order to preserve inferred SimulationResponseSuccess type.
-                ...unlock,
-                simulationResponse: unlock.simulationResponse,
-            };
-        }
+  // Find the first unlock that doesn't revert.
+  for (const unlock of unlocks) {
+    if (
+      unlock.simulationResponse &&
+      !("error" in unlock.simulationResponse) &&
+      !unlock.simulationResponse.firstRevert
+    ) {
+      return {
+        // Spread in order to preserve inferred SimulationResponseSuccess type.
+        ...unlock,
+        simulationResponse: unlock.simulationResponse,
+      };
     }
+  }
 
-    return undefined;
+  return undefined;
 };
 
 export const createUnlockLatestValueBundle = (signedUnlockTx: string, refundAddress: string, targetBlock: number) => {
-    // Create this as a bundle. Define the max share hints and share kickback to configured refund address.
-    const bundleParams: BundleParams = {
-        inclusion: { block: targetBlock, maxBlock: getMaxBlockByChainId(env.chainId, targetBlock) },
-        body: [{ tx: signedUnlockTx, canRevert: false }],
-        validity: {
-            refundConfig: [
-                {
-                    address: refundAddress,
-                    percent: 100,
-                },
-            ],
+  // Create this as a bundle. Define the max share hints and share kickback to configured refund address.
+  const bundleParams: BundleParams = {
+    inclusion: { block: targetBlock, maxBlock: getMaxBlockByChainId(env.chainId, targetBlock) },
+    body: [{ tx: signedUnlockTx, canRevert: false }],
+    validity: {
+      refundConfig: [
+        {
+          address: refundAddress,
+          percent: 100,
         },
-        privacy: {
-            hints: {
-                calldata: true,
-                logs: true,
-                contractAddress: true,
-                functionSelector: true,
-                txHash: true,
-            },
-            builders: env.builders,
-        },
-    };
+      ],
+    },
+    privacy: {
+      hints: {
+        calldata: true,
+        logs: true,
+        contractAddress: true,
+        functionSelector: true,
+        txHash: true,
+      },
+      builders: env.builders,
+    },
+  };
 
-    return bundleParams;
+  return bundleParams;
 };
 
 // Adjusts refund percent to ensure that net builder captured value reaches the minimum configured amount.
 // This can still return 0 if gross builder payment is not sufficient and caller should handle this.
 export const adjustRefundPercent = (grossBuilderPayment: bigint, originalRefundPercent: number) => {
-    // Require positive builder payment that covers at least minNetBuilderPaymentWei.
-    if (grossBuilderPayment <= 0 || grossBuilderPayment < env.minNetBuilderPaymentWei) return 0;
+  // Require positive builder payment that covers at least minNetBuilderPaymentWei.
+  if (grossBuilderPayment <= 0 || grossBuilderPayment < env.minNetBuilderPaymentWei) return 0;
 
-    // No need for scaling as Flashbots accepts only integer refund percent value.
-    const maxRefundPercent = Number(((grossBuilderPayment - env.minNetBuilderPaymentWei) * 100n) / grossBuilderPayment);
+  // No need for scaling as Flashbots accepts only integer refund percent value.
+  const maxRefundPercent = Number(((grossBuilderPayment - env.minNetBuilderPaymentWei) * 100n) / grossBuilderPayment);
 
-    // Bound adjusted refund percent by maxRefundPercent.
-    return Math.min(originalRefundPercent, maxRefundPercent);
+  // Bound adjusted refund percent by maxRefundPercent.
+  return Math.min(originalRefundPercent, maxRefundPercent);
 };
 
 // Send the bundle to MEV-Share and return the response.
-export const sendBundle = async (req: express.Request, res: express.Response, mevshare: MevShareClient, targetBlock: number, bodyId: JSONRPCID, bundle: BundleParams["body"], refunds: Refund[]) => {
+export const sendBundle = async (
+  req: express.Request,
+  res: express.Response,
+  mevshare: MevShareClient,
+  targetBlock: number,
+  bodyId: JSONRPCID,
+  bundle: BundleParams["body"],
+  refunds: Refund[],
+) => {
+  const bundleParams: BundleParams = {
+    inclusion: {
+      block: targetBlock,
+      maxBlock: getMaxBlockByChainId(env.chainId, targetBlock),
+    },
+    body: bundle,
+    privacy: {
+      builders: env.builders,
+    },
+    validity: {
+      refund: refunds,
+    },
+  };
 
-    const bundleParams: BundleParams = {
-        inclusion: {
-            block: targetBlock,
-            maxBlock: getMaxBlockByChainId(env.chainId, targetBlock),
-        },
-        body: bundle,
-        privacy: {
-            builders: env.builders,
-        },
-        validity: {
-            refund: refunds,
-        },
-    };
+  const backrunResult = await mevshare.sendBundle(bundleParams);
 
+  Logger.debug(req.transactionId, "Forwarded a bundle to MEV-Share", { bundleParams });
+  Logger.info(req.transactionId, "Bundle accepted by MEV-Share", { bundleHash: backrunResult.bundleHash });
 
-    const backrunResult = await mevshare.sendBundle(bundleParams);
-
-    Logger.debug(req.transactionId, "Forwarded a bundle to MEV-Share", { bundleParams });
-    Logger.info(req.transactionId, "Bundle accepted by MEV-Share", { bundleHash: backrunResult.bundleHash });
-
-    res.status(200).send(createJSONRPCSuccessResponse(bodyId, backrunResult));
-}
+  res.status(200).send(createJSONRPCSuccessResponse(bodyId, backrunResult));
+};

--- a/src/lib/bundleUtils.ts
+++ b/src/lib/bundleUtils.ts
@@ -1,0 +1,179 @@
+import { Interface, Transaction, TransactionRequest, Wallet } from "ethers";
+import express from "express";
+import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
+import { getBaseFee, getMaxBlockByChainId, getProvider, initWallets } from "./helpers";
+
+import MevShareClient, { BundleParams } from "@flashbots/mev-share-client";
+import { Logger } from "@uma/logger";
+import { JSONRPCID, createJSONRPCSuccessResponse } from "json-rpc-2.0";
+import { ovalAbi } from "../abi";
+import { env } from "./env";
+import { Refund } from "./types";
+const { ovalConfigs } = env;
+
+export const createUnlockLatestValueTx = async (
+    wallet: Wallet,
+    baseFee: bigint,
+    data: string,
+    chainId: bigint,
+    ovalAddress: string,
+) => {
+    const nonce = await wallet.getNonce();
+
+    // Construct transaction to call unlockLatestValue on Oval Oracle from permissioned address.
+    const unlockTx: TransactionRequest = {
+        type: 2,
+        chainId,
+        to: ovalAddress,
+        nonce,
+        value: 0,
+        gasLimit: 200000,
+        data,
+        // Double the current base fee as a basic safe gas estimate. We can make this more sophisticated in the future.
+        maxFeePerGas: baseFee * 2n,
+        maxPriorityFeePerGas: 0, // searcher should pay the full tip.
+    };
+
+    const signedUnlockTx = await wallet.signTransaction(unlockTx);
+
+    const unlockTxHash = Transaction.from(signedUnlockTx).hash;
+    if (!unlockTxHash) throw new Error("No hash in signed unlock transaction");
+
+    return { unlockTxHash, signedUnlockTx };
+};
+
+// Prepare unlockLatestValue transaction for a given Oval instance and simulate the bundle with the unlock transaction prepended if simulate is true.
+export const prepareUnlockTransaction = async (flashbotsBundleProvider: FlashbotsBundleProvider, backrunTxs: string[], targetBlock: number, ovalAddress: string, req: express.Request, simulate = true) => {
+    const provider = getProvider();
+    const unlockerWallets = initWallets(provider);
+    const ovalInterface = Interface.from(ovalAbi);
+    const [baseFee, network] = await Promise.all([getBaseFee(provider, req), provider.getNetwork()]);
+    const data = ovalInterface.encodeFunctionData("unlockLatestValue");
+    const { unlockTxHash, signedUnlockTx } = await createUnlockLatestValueTx(
+        unlockerWallets[ovalAddress],
+        baseFee,
+        data,
+        network.chainId,
+        ovalAddress,
+    );
+
+    if (!simulate) return { ovalAddress, unlockTxHash, signedUnlockTx };
+
+    const simulationResponse = await flashbotsBundleProvider.simulate([signedUnlockTx, ...backrunTxs], targetBlock);
+
+    return { ovalAddress, unlockTxHash, signedUnlockTx, simulationResponse };
+}
+
+export const getUnlockBundlesFromOvalAddresses = async (flashbotsBundleProvider: FlashbotsBundleProvider, backrunTxs: string[], targetBlock: number, ovalAddresses: string[], req: express.Request) => {
+    const unlockBundles = [];
+    const unlockSignedTransactions = [];
+    const unlockTxHashes = [];
+    for (const ovalAddress in ovalAddresses) {
+        const unlock = await prepareUnlockTransaction(flashbotsBundleProvider, backrunTxs, targetBlock, ovalAddress, req, false);
+
+        // Construct the inner bundle with call to Oval to unlock the latest value.
+        const unlockBundle = createUnlockLatestValueBundle(
+            unlock.signedUnlockTx,
+            ovalConfigs[ovalAddress].refundAddress,
+            targetBlock,
+        );
+
+        unlockBundles.push({ bundle: unlockBundle });
+        unlockSignedTransactions.push(unlock.signedUnlockTx);
+        unlockTxHashes.push(unlock.unlockTxHash);
+    }
+    return { unlockBundles, unlockSignedTransactions, unlockTxHashes };
+}
+
+// Simulate calls to unlockLatestValue on each Oval instance bundled with original backrun transactions. Tries to find
+// the first unlock that doesn't revert the bundle.
+export const findUnlock = async (
+    flashbotsBundleProvider: FlashbotsBundleProvider,
+    backrunTxs: string[],
+    targetBlock: number,
+    req: express.Request,
+) => {
+    const unlocks = await Promise.all(
+        Object.keys(ovalConfigs).map(async (ovalAddress) => (prepareUnlockTransaction(flashbotsBundleProvider, backrunTxs, targetBlock, ovalAddress, req))),
+    );
+
+    // Find the first unlock that doesn't revert.
+    for (const unlock of unlocks) {
+        if (unlock.simulationResponse && !("error" in unlock.simulationResponse) && !unlock.simulationResponse.firstRevert) {
+            return {
+                // Spread in order to preserve inferred SimulationResponseSuccess type.
+                ...unlock,
+                simulationResponse: unlock.simulationResponse,
+            };
+        }
+    }
+
+    return undefined;
+};
+
+export const createUnlockLatestValueBundle = (signedUnlockTx: string, refundAddress: string, targetBlock: number) => {
+    // Create this as a bundle. Define the max share hints and share kickback to configured refund address.
+    const bundleParams: BundleParams = {
+        inclusion: { block: targetBlock, maxBlock: getMaxBlockByChainId(env.chainId, targetBlock) },
+        body: [{ tx: signedUnlockTx, canRevert: false }],
+        validity: {
+            refundConfig: [
+                {
+                    address: refundAddress,
+                    percent: 100,
+                },
+            ],
+        },
+        privacy: {
+            hints: {
+                calldata: true,
+                logs: true,
+                contractAddress: true,
+                functionSelector: true,
+                txHash: true,
+            },
+            builders: env.builders,
+        },
+    };
+
+    return bundleParams;
+};
+
+// Adjusts refund percent to ensure that net builder captured value reaches the minimum configured amount.
+// This can still return 0 if gross builder payment is not sufficient and caller should handle this.
+export const adjustRefundPercent = (grossBuilderPayment: bigint, originalRefundPercent: number) => {
+    // Require positive builder payment that covers at least minNetBuilderPaymentWei.
+    if (grossBuilderPayment <= 0 || grossBuilderPayment < env.minNetBuilderPaymentWei) return 0;
+
+    // No need for scaling as Flashbots accepts only integer refund percent value.
+    const maxRefundPercent = Number(((grossBuilderPayment - env.minNetBuilderPaymentWei) * 100n) / grossBuilderPayment);
+
+    // Bound adjusted refund percent by maxRefundPercent.
+    return Math.min(originalRefundPercent, maxRefundPercent);
+};
+
+// Send the bundle to MEV-Share and return the response.
+export const sendBundle = async (req: express.Request, res: express.Response, mevshare: MevShareClient, targetBlock: number, bodyId: JSONRPCID, bundle: BundleParams["body"], refunds: Refund[]) => {
+
+    const bundleParams: BundleParams = {
+        inclusion: {
+            block: targetBlock,
+            maxBlock: getMaxBlockByChainId(env.chainId, targetBlock),
+        },
+        body: bundle,
+        privacy: {
+            builders: env.builders,
+        },
+        validity: {
+            refund: refunds,
+        },
+    };
+
+
+    const backrunResult = await mevshare.sendBundle(bundleParams);
+
+    Logger.debug(req.transactionId, "Forwarded a bundle to MEV-Share", { bundleParams });
+    Logger.info(req.transactionId, "Bundle accepted by MEV-Share", { bundleHash: backrunResult.bundleHash });
+
+    res.status(200).send(createJSONRPCSuccessResponse(bodyId, backrunResult));
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,13 +21,15 @@ export const fallback = {
 
 export const MAINNET_CHAIN_ID = 1;
 export const GOERLI_CHAIN_ID = 5;
+export const SEPOLIA_CHAIN_ID = 11155111;
 
-type SupportedNetworks = "mainnet" | "goerli";
+type SupportedNetworks = "mainnet" | "goerli" | "sepolia";
 export const supportedNetworks: {
   [key: number]: SupportedNetworks;
 } = {
   [MAINNET_CHAIN_ID]: "mainnet",
   [GOERLI_CHAIN_ID]: "goerli",
+  [SEPOLIA_CHAIN_ID]: "sepolia",
 };
 
 export const chainIdBlockOffsets: {
@@ -35,4 +37,33 @@ export const chainIdBlockOffsets: {
 } = {
   [MAINNET_CHAIN_ID]: 0,
   [GOERLI_CHAIN_ID]: 24,
+  [SEPOLIA_CHAIN_ID]: 24,
 };
+
+export const flashbotsSupportedNetworks: {
+  [key in SupportedNetworks]: {
+    name: string;
+    chainId: number;
+    streamUrl: string;
+    apiUrl: string;
+  }
+} = {
+  mainnet: {
+    name: "mainnet",
+    chainId: 1,
+    streamUrl: "https://mev-share.flashbots.net",
+    apiUrl: "https://relay.flashbots.net"
+  },
+  goerli: {
+    name: "goerli",
+    chainId: 5,
+    streamUrl: "https://mev-share-goerli.flashbots.net",
+    apiUrl: "https://relay-goerli.flashbots.net"
+  },
+  sepolia: {
+    name: "sepolia",
+    chainId: 11155111,
+    streamUrl: "https://mev-share-sepolia.flashbots.net",
+    apiUrl: "https://relay-sepolia.flashbots.net"
+  }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -46,27 +46,27 @@ export const flashbotsSupportedNetworks: {
     chainId: number;
     streamUrl: string;
     apiUrl: string;
-  }
+  };
 } = {
   mainnet: {
     name: "mainnet",
     chainId: 1,
     streamUrl: "https://mev-share.flashbots.net",
-    apiUrl: "https://relay.flashbots.net"
+    apiUrl: "https://relay.flashbots.net",
   },
   goerli: {
     name: "goerli",
     chainId: 5,
     streamUrl: "https://mev-share-goerli.flashbots.net",
-    apiUrl: "https://relay-goerli.flashbots.net"
+    apiUrl: "https://relay-goerli.flashbots.net",
   },
   sepolia: {
     name: "sepolia",
     chainId: 11155111,
     streamUrl: "https://mev-share-sepolia.flashbots.net",
-    apiUrl: "https://relay-sepolia.flashbots.net"
-  }
-}
+    apiUrl: "https://relay-sepolia.flashbots.net",
+  },
+};
 
 export const FLASHBOTS_SIGNATURE_HEADER = "x-flashbots-signature";
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -67,3 +67,7 @@ export const flashbotsSupportedNetworks: {
     apiUrl: "https://relay-sepolia.flashbots.net"
   }
 }
+
+export const FLASHBOTS_SIGNATURE_HEADER = "x-flashbots-signature";
+
+export const OVAL_CONFIG_HEADER = "x-oval-config";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,4 +70,4 @@ export const flashbotsSupportedNetworks: {
 
 export const FLASHBOTS_SIGNATURE_HEADER = "x-flashbots-signature";
 
-export const OVAL_CONFIG_HEADER = "x-oval-config";
+export const OVAL_ADDRESSES_HEADER = "x-oval-addresses";

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,7 @@
-import { getAddress, parseEther } from "ethers";
 import dotenv from "dotenv";
+import { getAddress, parseEther } from "ethers";
 import { fallback, supportedNetworks } from "./constants";
-import { getBoolean, getInt, getFloat, getStringArray, getOvalConfigs, getPrivateKey } from "./helpers";
+import { getBoolean, getFloat, getInt, getOvalConfigs, getPrivateKey, getStringArray } from "./helpers";
 import { OvalConfigs } from "./types";
 dotenv.config({ path: ".env" });
 
@@ -44,5 +44,6 @@ export const env = {
   passThroughNonReverting: getBoolean(
     getEnvVar("PASS_THROUGH_NON_REVERTING", fallback.passThroughNonReverting.toString()),
   ),
+  maxOvalHeaderAddresses: getInt(getEnvVar("MAX_OVAL_HEADER_ADDRESSES", "5")),
   flashbotsOrigin: process.env["FLASHBOTS_ORIGIN"],
 };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -254,21 +254,23 @@ export const getOvalHeaderConfigs = (
     if (!Array.isArray(ovalAddresses) || !ovalAddresses.every(isAddress)) {
       throw new Error(`Value "${header}" is not a valid array of Ethereum addresses`);
     }
-    if (ovalAddresses.some((ovalAddress) => !ovalConfigs[ovalAddress])) {
+    // Normalise addresses and check if they are valid Oval instances.
+    const normalisedAddresses = ovalAddresses.map(getAddress);
+    if (normalisedAddresses.some((ovalAddress) => !ovalConfigs[ovalAddress])) {
       throw new Error(`Some addresses in "${header}" are not valid Oval instances`);
     }
-    const uniqueRefundAddresses = new Set(ovalAddresses.map((address) => ovalConfigs[address].refundAddress));
+    const uniqueRefundAddresses = new Set(normalisedAddresses.map((address) => ovalConfigs[address].refundAddress));
     if (uniqueRefundAddresses.size > 1) {
       throw new Error(`Value "${header}" only supports a single refund address`);
     }
-    const uniqueAddresses = new Set(ovalAddresses);
-    if (uniqueAddresses.size !== ovalAddresses.length) {
+    const uniqueAddresses = new Set(normalisedAddresses);
+    if (uniqueAddresses.size !== normalisedAddresses.length) {
       throw new Error(`Value "${header}" contains duplicate addresses`);
     }
-    if (ovalAddresses.length > env.maxOvalHeaderAddresses) {
+    if (normalisedAddresses.length > env.maxOvalHeaderAddresses) {
       throw new Error(`Value "${header}" contains more than ${env.maxOvalHeaderAddresses} addresses`);
     }
-    return { ovalAddresses: ovalAddresses.map(getAddress) }; // Normalise addresses.
+    return { ovalAddresses: normalisedAddresses };
   } catch (error) {
     return { ovalAddresses: undefined, errorMessage: (error as Error).message };
   }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -252,7 +252,6 @@ export const calculateBundleRefunds = (unlockAddresses: string[], ovalConfigs: O
   const refunds = new Map<string, Refund>();
   // We split the refund percentage equally between the unlock addresses and for each we calculate the refund according
   // Oval instance refund percentage in OvalConfigs.
-  // Note: In the future we might want to support different refund percentages for different unlock addresses.
   const split = 100 / unlockAddresses.length;
   for (let i = 0; i < unlockAddresses.length; i++) {
     const ovalAddress = unlockAddresses[i];

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -221,23 +221,30 @@ export function getOvalConfigs(input: string): OvalConfigs {
 }
 
 // Get OvalHeaderConfigs from the header string or throw an error if the header is invalid.
-export const getOvalHeaderConfigs = (header: string | string[] | undefined, ovalConfigs: OvalConfigs): { valid: boolean, ovalHeaderConfigs: OvalHeaderConfigs | undefined } => {
+export const getOvalHeaderConfigs = (
+  header: string | string[] | undefined,
+  ovalConfigs: OvalConfigs,
+): { valid: boolean; ovalHeaderConfigs: OvalHeaderConfigs | undefined } => {
   if (!header) return { valid: true, ovalHeaderConfigs: undefined };
-  if (typeof header !== 'string') return { valid: false, ovalHeaderConfigs: undefined };
+  if (typeof header !== "string") return { valid: false, ovalHeaderConfigs: undefined };
 
   let ovalHeaderConfigs: OvalHeaderConfigs;
   let valid = true;
   try {
     ovalHeaderConfigs = JSON.parse(header);
-    if (!ovalHeaderConfigs.unlockAddresses) throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
-    if (!Array.isArray(ovalHeaderConfigs.unlockAddresses)) throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
-    if (ovalHeaderConfigs.unlockAddresses.find((ovalHeaderConfig) => !isAddress(ovalHeaderConfig.ovalAddress))) throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
-    if (ovalHeaderConfigs.unlockAddresses.find((ovalHeaderConfig) => !ovalConfigs[ovalHeaderConfig.ovalAddress])) throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
+    if (!ovalHeaderConfigs.unlockAddresses)
+      throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
+    if (!Array.isArray(ovalHeaderConfigs.unlockAddresses))
+      throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
+    if (ovalHeaderConfigs.unlockAddresses.find((ovalHeaderConfig) => !isAddress(ovalHeaderConfig.ovalAddress)))
+      throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
+    if (ovalHeaderConfigs.unlockAddresses.find((ovalHeaderConfig) => !ovalConfigs[ovalHeaderConfig.ovalAddress]))
+      throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
   } catch {
     return { valid: false, ovalHeaderConfigs: undefined };
   }
   return { valid, ovalHeaderConfigs };
-}
+};
 
 // Calculate refunds for the each unlock bundles this assumes the unlock bundles are the first elements in the bundle
 // and the unlockAddresses are in the same order as the unlock bundles.
@@ -248,8 +255,8 @@ export const calculateBundleRefunds = (unlockAddresses: string[], ovalConfigs: O
   // Note: In the future we might want to support different refund percentages for different unlock addresses.
   const split = 100 / unlockAddresses.length;
   for (let i = 0; i < unlockAddresses.length; i++) {
-    const ovalAddress = unlockAddresses[i]
-    const refundToAdd = floorToDecimals(split * ovalConfigs[ovalAddress].refundPercent / 100, 3);
+    const ovalAddress = unlockAddresses[i];
+    const refundToAdd = floorToDecimals((split * ovalConfigs[ovalAddress].refundPercent) / 100, 3);
     const existingRefund = refunds.get(ovalAddress);
     if (existingRefund) {
       // Avoid duplicate refunds for the same Oval instance. We combine them into a single refund.
@@ -259,7 +266,7 @@ export const calculateBundleRefunds = (unlockAddresses: string[], ovalConfigs: O
     }
   }
   return Object.values(refunds);
-}
+};
 
 // Verify the bundle signature header and return the address of the private key that produced the searchers signature if
 // valid, otherwise return null.

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,12 +1,12 @@
-import { JsonRpcProvider, Network, Wallet, Provider, isAddress, isHexString, Transaction, ethers } from "ethers";
-import MevShareClient, { SupportedNetworks } from "@flashbots/mev-share-client";
+import MevShareClient from "@flashbots/mev-share-client";
+import { JsonRpcProvider, Network, Provider, Transaction, Wallet, ethers, isAddress, isHexString } from "ethers";
+import { Request } from "express";
 import { FlashbotsBundleProvider } from "flashbots-ethers-v6-provider-bundle";
+import { JSONRPCRequest } from "json-rpc-2.0";
+import { chainIdBlockOffsets, flashbotsSupportedNetworks, supportedNetworks } from "./constants";
 import { env } from "./env";
 import { Logger } from "./logging";
-import { OvalConfig, OvalConfigs } from "./types";
-import { JSONRPCRequest } from "json-rpc-2.0";
-import { Request } from "express";
-import { chainIdBlockOffsets, flashbotsSupportedNetworks, supportedNetworks } from "./constants";
+import { OvalConfig, OvalConfigs, OvalHeaderConfigs, Refund } from "./types";
 
 export function getProvider() {
   const network = new Network(supportedNetworks[env.chainId], env.chainId);
@@ -220,6 +220,47 @@ export function getOvalConfigs(input: string): OvalConfigs {
   throw new Error(`Value "${input}" is valid JSON but is not OvalConfigs records`);
 }
 
+// Get OvalHeaderConfigs from the header string or throw an error if the header is invalid.
+export const getOvalHeaderConfigs = (header: string | string[] | undefined, ovalConfigs: OvalConfigs): { valid: boolean, ovalHeaderConfigs: OvalHeaderConfigs | undefined } => {
+  if (!header) return { valid: true, ovalHeaderConfigs: undefined };
+  if (typeof header !== 'string') return { valid: false, ovalHeaderConfigs: undefined };
+
+  let ovalHeaderConfigs: OvalHeaderConfigs;
+  let valid = true;
+  try {
+    ovalHeaderConfigs = JSON.parse(header);
+    if (!ovalHeaderConfigs.unlockAddresses) throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
+    if (!Array.isArray(ovalHeaderConfigs.unlockAddresses)) throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
+    if (ovalHeaderConfigs.unlockAddresses.find((ovalHeaderConfig) => !isAddress(ovalHeaderConfig.ovalAddress))) throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
+    if (ovalHeaderConfigs.unlockAddresses.find((ovalHeaderConfig) => !ovalConfigs[ovalHeaderConfig.ovalAddress])) throw new Error(`Value "${header}" cannot be converted to OvalConfigs records`);
+  } catch {
+    return { valid: false, ovalHeaderConfigs: undefined };
+  }
+  return { valid, ovalHeaderConfigs };
+}
+
+// Calculate refunds for the each unlock bundles this assumes the unlock bundles are the first elements in the bundle
+// and the unlockAddresses are in the same order as the unlock bundles.
+export const calculateBundleRefunds = (unlockAddresses: string[], ovalConfigs: OvalConfigs): Refund[] => {
+  const refunds = new Map<string, Refund>();
+  // We split the refund percentage equally between the unlock addresses and for each we calculate the refund according
+  // Oval instance refund percentage in OvalConfigs.
+  // Note: In the future we might want to support different refund percentages for different unlock addresses.
+  const split = 100 / unlockAddresses.length;
+  for (let i = 0; i < unlockAddresses.length; i++) {
+    const ovalAddress = unlockAddresses[i]
+    const refundToAdd = floorToDecimals(split * ovalConfigs[ovalAddress].refundPercent / 100, 3);
+    const existingRefund = refunds.get(ovalAddress);
+    if (existingRefund) {
+      // Avoid duplicate refunds for the same Oval instance. We combine them into a single refund.
+      refunds.set(ovalAddress, { bodyIdx: existingRefund.bodyIdx, percent: existingRefund.percent + refundToAdd });
+    } else {
+      refunds.set(ovalAddress, { bodyIdx: i, percent: refundToAdd });
+    }
+  }
+  return Object.values(refunds);
+}
+
 // Verify the bundle signature header and return the address of the private key that produced the searchers signature if
 // valid, otherwise return null.
 export function verifyBundleSignature(
@@ -258,4 +299,10 @@ export function getPrivateKey(input: string): string {
 export function getMaxBlockByChainId(chainId: number, targetBlock: number) {
   // In mainnet this is always the targetBlock, but in Goerli we add 24 blocks to the targetBlock.
   return targetBlock + chainIdBlockOffsets[chainId];
+}
+
+// Helper function to floor a number to a given number of decimals.
+export function floorToDecimals(value: number, decimals: number): number {
+  const factor = Math.pow(10, decimals);
+  return Math.floor(value * factor) / factor;
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -6,7 +6,7 @@ import { Logger } from "./logging";
 import { OvalConfig, OvalConfigs } from "./types";
 import { JSONRPCRequest } from "json-rpc-2.0";
 import { Request } from "express";
-import { chainIdBlockOffsets, supportedNetworks } from "./constants";
+import { chainIdBlockOffsets, flashbotsSupportedNetworks, supportedNetworks } from "./constants";
 
 export function getProvider() {
   const network = new Network(supportedNetworks[env.chainId], env.chainId);
@@ -37,7 +37,7 @@ export async function initClients(provider: JsonRpcProvider, searcherPublicKey: 
 
   // Use custom network for MevShare and connect for FlashbotsBundle as we might need adding x-flashbots-origin headers.
   const network = {
-    streamUrl: SupportedNetworks[supportedNetworks[env.chainId]].streamUrl,
+    streamUrl: flashbotsSupportedNetworks[supportedNetworks[env.chainId]].streamUrl,
     apiUrl: env.forwardUrl,
     apiHeaders: env.flashbotsOrigin !== undefined ? { "x-flashbots-origin": env.flashbotsOrigin } : undefined,
   };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,5 @@ export * from "./env";
 export * from "./helpers";
 export * from "./types";
 export * from "./logging";
+export * from "./bundleUtils";
+export * from "./constants";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,19 +12,10 @@ export type Refund = {
   percent: number;
 };
 
-export interface OvalHeaderConfigs {
-  unlockAddresses: {
-    ovalAddress: string;
-  }[];
-}
-
 type EthereumAddress = string;
 
 export interface UnlockAddress {
   ovalAddress: EthereumAddress;
 }
 
-export interface OvalHeaderConfigs {
-  unlockAddresses: UnlockAddress[];
-  additionalData?: Record<string, any>; // Placeholder for future expansion, not used at the moment.
-}
+export type OvalAddressConfigList = string[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,3 +6,25 @@ export interface OvalConfig {
 
 // Records to store supported Oval instances and their configs.
 export type OvalConfigs = Record<string, OvalConfig>;
+
+export type Refund = {
+  bodyIdx: number;
+  percent: number;
+};
+
+export interface OvalHeaderConfigs {
+  unlockAddresses: {
+    ovalAddress: string;
+  }[]
+}
+
+type EthereumAddress = string;
+
+export interface UnlockAddress {
+  ovalAddress: EthereumAddress;
+}
+
+export interface OvalHeaderConfigs {
+  unlockAddresses: UnlockAddress[];
+  additionalData?: Record<string, any>; // Placeholder for future expansion, not used at the moment.
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,7 +15,7 @@ export type Refund = {
 export interface OvalHeaderConfigs {
   unlockAddresses: {
     ovalAddress: string;
-  }[]
+  }[];
 }
 
 type EthereumAddress = string;


### PR DESCRIPTION
Changes proposed in this PR:
- Add a new header that can be passed in the `eth_sendBundle` and `eth_callBundle` commands with the `OvalHeaderConfigs`, containing the oval addresses to be unlocked and the unlocks prepended to the backrun bundle.
- The new config allows for the passing of multiple oval addresses to be unlocked. The refunds are split equally among the different oval implementations according to their configuration.
- Reorganize some files and functions to improve readability.