### PR TITLE
fix: header refund config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,11 +111,13 @@ app.post("/", async (req, res, next) => {
           }),
         ];
 
-        // A single refund address is required for bundles using header unlocks.
+        // A single refund address across all the bundles is required for bundles using header unlocks.
+        // This is enforced in getOvalHeaderConfigs
         refunds = [
           {
             bodyIdx: 0,
-            percent: ovalConfigs[headerOvalAddresses[0]].refundPercent, // This requires a single refund address. see getOvalHeaderConfigs
+            // Next line is dependent on all Oval addresses having the same refund address
+            percent: ovalConfigs[headerOvalAddresses[0]].refundPercent,
           },
         ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,12 +111,11 @@ app.post("/", async (req, res, next) => {
           }),
         ];
 
-        // A single refund address is required for bundles using header unlocks, with 100% of the refund directed to the
-        // first unlock's address, ensuring consistency.
+        // A single refund address is required for bundles using header unlocks.
         refunds = [
           {
             bodyIdx: 0,
-            percent: 100,
+            percent: ovalConfigs[headerOvalAddresses[0]].refundPercent, // This requires a single refund address. see getOvalHeaderConfigs
           },
         ];
 


### PR DESCRIPTION
Changes proposed in this PR:

- Fixes the Oval node refund configurations. Previously, with the bug, all bundles with Oval address headers configured were sent with a 100% refund configuration. In over 95% of cases, Flashbots enforced a [90% refund as described in their documentation](https://docs.flashbots.net/flashbots-protect/quick-start#:~:text=Earn%20MEV%20refunds%3A%20If%20your,pay%20fees%20for%20failed%20transactions). However, Flashbots Builder 2 allows a 100% refund, and it produces blocks approximately 2.5% of the time. This is why this bug has remained undetected until now.