### PR TITLE
feat(walletManager): add shouldRecordUsage option and tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,7 +235,8 @@ app.post("/", async (req, res, next) => {
       } else {
         Logger.debug(req.transactionId, "Finding unlock that does not revert the bundle...");
 
-        const unlock = await findUnlock(flashbotsBundleProvider, backrunTxs, targetBlock, req);
+        // FindUnlock with recordWalletUsage set to false to prevent recording wallet usage in WalletManager.
+        const unlock = await findUnlock(flashbotsBundleProvider, backrunTxs, targetBlock, req, false);
         if (!unlock) {
           Logger.debug(req.transactionId, "No valid unlock found!");
           await handleUnsupportedRequest(req, res, "No valid unlock found"); // Pass through if no unlock is found.


### PR DESCRIPTION
Changes proposed in this PR:
- Introduced `shouldRecordUsage` optional boolean argument to `getWallet` and `getSharedWallet` methods.
- Added tests to verify the functionality of the `shouldRecordUsage` option.
- Implemented to avoid recording usage when finding an unlock in [findUnlock](https://github.com/UMAprotocol/oval-node/blob/5f05e0c0b526e500413a802cb836b14d5889fe4b/src/lib/bundleUtils.ts#L121) function.

